### PR TITLE
Supprime les lignes @version SVN $Id$

### DIFF
--- a/class/AdminPage.php
+++ b/class/AdminPage.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist;

--- a/class/Autoloader.php
+++ b/class/Autoloader.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist;
 

--- a/class/Cache/FileCache.php
+++ b/class/Cache/FileCache.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Cache
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Cache;

--- a/class/Controller.php
+++ b/class/Controller.php
@@ -10,8 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id: AbstractActions.php 506 2013-03-13 16:30:08Z
- * daniel.menard.35@gmail.com $
  */
 
 namespace Docalist;

--- a/class/Core/AdminTables.php
+++ b/class/Core/AdminTables.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tables
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Core;
 

--- a/class/Core/Installer.php
+++ b/class/Core/Installer.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Core;

--- a/class/Core/Plugin.php
+++ b/class/Core/Plugin.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Core;

--- a/class/Core/Settings.php
+++ b/class/Core/Settings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Core;
 

--- a/class/Forms/Assets.php
+++ b/class/Forms/Assets.php
@@ -10,8 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id: Button.php 396 2013-02-11 12:09:16Z
- * daniel.menard.35@gmail.com $
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Button.php
+++ b/class/Forms/Button.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Checkbox.php
+++ b/class/Forms/Checkbox.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Checklist.php
+++ b/class/Forms/Checklist.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Choice.php
+++ b/class/Forms/Choice.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Div.php
+++ b/class/Forms/Div.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Field.php
+++ b/class/Forms/Field.php
@@ -10,8 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id: Field.php 397 2013-02-11 15:30:06Z
- * daniel.menard.35@gmail.com $
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Fields.php
+++ b/class/Forms/Fields.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Fieldset.php
+++ b/class/Forms/Fieldset.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Form.php
+++ b/class/Forms/Form.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Fragment.php
+++ b/class/Forms/Fragment.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Hidden.php
+++ b/class/Forms/Hidden.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Input.php
+++ b/class/Forms/Input.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Password.php
+++ b/class/Forms/Password.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Radio.php
+++ b/class/Forms/Radio.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Reset.php
+++ b/class/Forms/Reset.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Select.php
+++ b/class/Forms/Select.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Submit.php
+++ b/class/Forms/Submit.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Table.php
+++ b/class/Forms/Table.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/TableLookup.php
+++ b/class/Forms/TableLookup.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Tag.php
+++ b/class/Forms/Tag.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Textarea.php
+++ b/class/Forms/Textarea.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/Themes.php
+++ b/class/Forms/Themes.php
@@ -10,8 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id: Themes.php 398 2013-02-11 15:32:10Z
- * daniel.menard.35@gmail.com $
  */
 
 namespace Docalist\Forms;

--- a/class/Forms/TopicsInput.php
+++ b/class/Forms/TopicsInput.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Forms;

--- a/class/Http/CallbackResponse.php
+++ b/class/Http/CallbackResponse.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Response
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Http;
 

--- a/class/Http/HtmlResponse.php
+++ b/class/Http/HtmlResponse.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Response
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Http;
 

--- a/class/Http/JsonResponse.php
+++ b/class/Http/JsonResponse.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Response
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Http;
 

--- a/class/Http/RedirectResponse.php
+++ b/class/Http/RedirectResponse.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Response
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Http;
 

--- a/class/Http/Request.php
+++ b/class/Http/Request.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Response
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Http;
 

--- a/class/Http/Response.php
+++ b/class/Http/Response.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Response
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Http;
 

--- a/class/Http/TextResponse.php
+++ b/class/Http/TextResponse.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Response
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Http;
 

--- a/class/Http/ViewResponse.php
+++ b/class/Http/ViewResponse.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Response
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Http;
 

--- a/class/LogManager.php
+++ b/class/LogManager.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 
 namespace Docalist;

--- a/class/Lookup.php
+++ b/class/Lookup.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist;

--- a/class/MonologLogger.php
+++ b/class/MonologLogger.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 
 namespace Docalist;

--- a/class/Repository/ConfigRepository.php
+++ b/class/Repository/ConfigRepository.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Repository;
 

--- a/class/Repository/DirectoryRepository.php
+++ b/class/Repository/DirectoryRepository.php
@@ -8,7 +8,6 @@
  * @package Docalist
  * @subpackage Core
  * @author Daniel Ménard <daniel.menard@laposte.net>
- * @version SVN: $Id$
  */
 namespace Docalist\Repository;
 

--- a/class/Repository/Exception/BadIdException.php
+++ b/class/Repository/Exception/BadIdException.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Repository\Exception;
 

--- a/class/Repository/Exception/EntityNotFoundException.php
+++ b/class/Repository/Exception/EntityNotFoundException.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Repository\Exception;
 

--- a/class/Repository/Exception/RepositoryException.php
+++ b/class/Repository/Exception/RepositoryException.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Repository\Exception;
 

--- a/class/Repository/PostTypeRepository.php
+++ b/class/Repository/PostTypeRepository.php
@@ -10,7 +10,6 @@
  * @package Docalist
  * @subpackage Core
  * @author Daniel Ménard <daniel.menard@laposte.net>
- * @version SVN: $Id$
  */
 namespace Docalist\Repository;
 

--- a/class/Repository/Repository.php
+++ b/class/Repository/Repository.php
@@ -10,7 +10,6 @@
  * @package Docalist
  * @subpackage Core
  * @author Daniel Ménard <daniel.menard@laposte.net>
- * @version SVN: $Id$
  */
 namespace Docalist\Repository;
 

--- a/class/Repository/SettingsRepository.php
+++ b/class/Repository/SettingsRepository.php
@@ -10,7 +10,6 @@
  * @package Docalist
  * @subpackage Core
  * @author Daniel Ménard <daniel.menard@laposte.net>
- * @version SVN: $Id$
  */
 namespace Docalist\Repository;
 

--- a/class/Schema/Field.php
+++ b/class/Schema/Field.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Schema;
 

--- a/class/Schema/Schema.php
+++ b/class/Schema/Schema.php
@@ -10,7 +10,6 @@
  * @package Docalist
  * @subpackage Core
  * @author Daniel Ménard <daniel.menard@laposte.net>
- * @version SVN: $Id$
  */
 namespace Docalist\Schema;
 

--- a/class/Sequences.php
+++ b/class/Sequences.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist;

--- a/class/Services.php
+++ b/class/Services.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist;

--- a/class/Table/CsvTable.php
+++ b/class/Table/CsvTable.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Table
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Table;
 

--- a/class/Table/MasterTable.php
+++ b/class/Table/MasterTable.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Table
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Table;
 

--- a/class/Table/PhpTable.php
+++ b/class/Table/PhpTable.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Table
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Table;
 

--- a/class/Table/SQLite.php
+++ b/class/Table/SQLite.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Table
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Table;
 

--- a/class/Table/TableInfo.php
+++ b/class/Table/TableInfo.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Table
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Table;
 

--- a/class/Table/TableInterface.php
+++ b/class/Table/TableInterface.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Table
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Table;
 

--- a/class/Table/TableManager.php
+++ b/class/Table/TableManager.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Table
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Table;
 

--- a/class/Tokenizer.php
+++ b/class/Tokenizer.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist;
 

--- a/class/Type/Any.php
+++ b/class/Type/Any.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/Boolean.php
+++ b/class/Type/Boolean.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/Collection.php
+++ b/class/Type/Collection.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/Entity.php
+++ b/class/Type/Entity.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/Exception/InvalidTypeException.php
+++ b/class/Type/Exception/InvalidTypeException.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type\Exception;
 

--- a/class/Type/Float.php
+++ b/class/Type/Float.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/Integer.php
+++ b/class/Type/Integer.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/Object.php
+++ b/class/Type/Object.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/Scalar.php
+++ b/class/Type/Scalar.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/Settings.php
+++ b/class/Type/Settings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Type/String.php
+++ b/class/Type/String.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Type;
 

--- a/class/Utils.php
+++ b/class/Utils.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist;

--- a/class/Views.php
+++ b/class/Views.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 
 namespace Docalist;

--- a/docalist-core.php
+++ b/docalist-core.php
@@ -19,7 +19,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Core;

--- a/docalist.php
+++ b/docalist.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 
 // pas de namespace, la fonction docalist() est globale.

--- a/tables/countries/ISO-3166-1_alpha2_en.txt
+++ b/tables/countries/ISO-3166-1_alpha2_en.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/countries/ISO-3166-1_alpha2_fr.txt
+++ b/tables/countries/ISO-3166-1_alpha2_fr.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/countries/ISO-3166-1_alpha3-to-alpha2.txt
+++ b/tables/countries/ISO-3166-1_alpha3-to-alpha2.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/languages/ISO-639-2_alpha2-to-alpha3.txt
+++ b/tables/languages/ISO-639-2_alpha2-to-alpha3.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/languages/ISO-639-2_alpha3_EU_en.txt
+++ b/tables/languages/ISO-639-2_alpha3_EU_en.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/languages/ISO-639-2_alpha3_EU_fr.txt
+++ b/tables/languages/ISO-639-2_alpha3_EU_fr.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/languages/ISO-639-2_alpha3_en.txt
+++ b/tables/languages/ISO-639-2_alpha3_en.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/languages/ISO-639-2_alpha3_fr.txt
+++ b/tables/languages/ISO-639-2_alpha3_fr.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tests/Docalist/Repository/ConfigRepositoryTest.php
+++ b/tests/Docalist/Repository/ConfigRepositoryTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Repository;

--- a/tests/Docalist/Repository/DirectoryRepositoryTest.php
+++ b/tests/Docalist/Repository/DirectoryRepositoryTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Repository;

--- a/tests/Docalist/Repository/PostTypeRepositoryTest.php
+++ b/tests/Docalist/Repository/PostTypeRepositoryTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Repository;

--- a/tests/Docalist/Repository/RepositoryTest.php
+++ b/tests/Docalist/Repository/RepositoryTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Repository;

--- a/tests/Docalist/Repository/SettingsRepositoryTest.php
+++ b/tests/Docalist/Repository/SettingsRepositoryTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Repository;

--- a/tests/Docalist/Repository/fixtures/MemoryRepository.php
+++ b/tests/Docalist/Repository/fixtures/MemoryRepository.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Repository\Fixtures;

--- a/tests/Docalist/Type/AnyTest.php
+++ b/tests/Docalist/Type/AnyTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/BooleanTest.php
+++ b/tests/Docalist/Type/BooleanTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/CollectionTest.php
+++ b/tests/Docalist/Type/CollectionTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/EntityTest.php
+++ b/tests/Docalist/Type/EntityTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/FloatTest.php
+++ b/tests/Docalist/Type/FloatTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/IntegerTest.php
+++ b/tests/Docalist/Type/IntegerTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/ObjectTest.php
+++ b/tests/Docalist/Type/ObjectTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/ScalarTest.php
+++ b/tests/Docalist/Type/ScalarTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/SettingsTest.php
+++ b/tests/Docalist/Type/SettingsTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/StringTest.php
+++ b/tests/Docalist/Type/StringTest.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type;

--- a/tests/Docalist/Type/fixtures/Client.php
+++ b/tests/Docalist/Type/fixtures/Client.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type\Fixtures;

--- a/tests/Docalist/Type/fixtures/Facture.php
+++ b/tests/Docalist/Type/fixtures/Facture.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type\Fixtures;

--- a/tests/Docalist/Type/fixtures/GlobalType.php
+++ b/tests/Docalist/Type/fixtures/GlobalType.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 use Docalist\Type\Any;

--- a/tests/Docalist/Type/fixtures/Money.php
+++ b/tests/Docalist/Type/fixtures/Money.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type\Fixtures;

--- a/tests/Docalist/Type/fixtures/MySettings.php
+++ b/tests/Docalist/Type/fixtures/MySettings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Tests
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Tests\Type\Fixtures;

--- a/views/confirm.php
+++ b/views/confirm.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 

--- a/views/controller/access-denied.php
+++ b/views/controller/access-denied.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 

--- a/views/controller/action-not-found.php
+++ b/views/controller/action-not-found.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 

--- a/views/controller/actions-list.php
+++ b/views/controller/actions-list.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 

--- a/views/controller/bad-request.php
+++ b/views/controller/bad-request.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 

--- a/views/error.php
+++ b/views/error.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace DocalistViews;
 

--- a/views/forms/docalist-forms.js
+++ b/views/forms/docalist-forms.js
@@ -9,7 +9,6 @@
  * @package     Docalist
  * @subpackage  Forms
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 jQuery(document).ready(function($) {

--- a/views/info.php
+++ b/views/info.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 

--- a/views/table/copy.php
+++ b/views/table/copy.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 

--- a/views/table/edit.php
+++ b/views/table/edit.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 

--- a/views/table/list.php
+++ b/views/table/list.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 use Docalist\Table\TableInfo;

--- a/views/table/properties.php
+++ b/views/table/properties.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Views
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Views;
 


### PR DESCRIPTION
$Id$ est l'un des mots-clés auto reconnus par SVN. Cela permettait
d'avoir, directement dans le code source, le numéro de révision du
fichier.

Comme il n'y a pas d'équivalent dans git, suppression de cette ligne
dans tous les fichiers (y compris les tables).